### PR TITLE
Escape entire class name not just user provided-portion

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 module.exports = function({ ratios, variants }) {
   return function({ addUtilities, e }) {
     const utilities = _.map(ratios, ([width, height], name) => ({
-      [`.aspect-ratio-${e(name)}`]: {
+      [`.${e(`aspect-ratio-${name}`)}`]: {
         paddingTop: `${((Math.round(height) / Math.round(width)) * 100).toFixed(2)}%`
       }
     }))


### PR DESCRIPTION
We use a more robust escape function as of Tailwind 0.6 (https://github.com/mathiasbynens/CSS.escape) that escapes strings for use in class names in a fully spec-compliant way.

This is awesome overall, but it treats strings that start with numbers differently than how our original implementation did. That's because CSS classes can't actually start with numbers, so if you try to escape a string that starts with a number (like '16/9'), the new function will escape the '1' because it doesn't know it's not the first character of a class name.

This is fine, everything still works, but the output is uglier and longer. By escaping the full class name portion at once, the function know it doesn't start with a number and doesn't escape that character unnecessarily.